### PR TITLE
Add browsing of Sonos favorites

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@
  Also, if you have songs favorited with youtube music they will play, at this time, playlists, albums, and stations with youtube music do not work, i dont use a lot of other streaming media so havent tested others. 
  this also shows the now playing album art and track info on the screen and you can control the volume. 
  If anyone wants to use it will be an alpha/early beta i guess.
+
+## Browsing Favorites
+
+Container favorites (such as folders or playlists) can now be explored. Clicking a favorite that represents a container opens a modal showing its children. Items in the modal can be played directly or, if they are containers themselves, browsed further.

--- a/server/setupGetters.ts
+++ b/server/setupGetters.ts
@@ -20,6 +20,13 @@ export const setupGetters = () => {
       case 'zoneGroupState':
         await sonos.getZoneGroupState();
         break;
+
+      case 'browseFavorite':
+        if (payload?.id) {
+          const children = await sonos.browseFavorite(payload.id);
+          DeskThing.send({ app: 'sonos-webapp', type: 'favoriteChildren', payload: children });
+        }
+        break;
         
         case 'volume':
        if (payload?.speakerUUIDs) {

--- a/src/components/FavoriteModal.css
+++ b/src/components/FavoriteModal.css
@@ -1,0 +1,48 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.favorite-modal {
+  background: #222;
+  padding: 20px;
+  border-radius: 8px;
+  max-height: 80vh;
+  overflow-y: auto;
+  color: #fff;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.modal-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.modal-item img {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.modal-actions {
+  margin-top: 4px;
+  display: flex;
+  gap: 4px;
+}
+
+.close-button {
+  margin-bottom: 10px;
+}

--- a/src/components/FavoriteModal.tsx
+++ b/src/components/FavoriteModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Favorite } from './Favorites';
+import './FavoriteModal.css';
+
+interface Props {
+  items: Favorite[];
+  onClose: () => void;
+  onPlay: (fav: Favorite) => void;
+  onBrowse: (fav: Favorite) => void;
+}
+
+const FavoriteModal: React.FC<Props> = ({ items, onClose, onPlay, onBrowse }) => {
+  return (
+    <div className="modal-overlay">
+      <div className="favorite-modal">
+        <button className="close-button" onClick={onClose}>
+          Close
+        </button>
+        <div className="modal-grid">
+          {items.map((fav) => (
+            <div key={fav.id} className="modal-item">
+              <img src={fav.albumArt || ''} alt={fav.title} />
+              <div className="modal-title">{fav.title}</div>
+              <div className="modal-actions">
+                <button onClick={() => onPlay(fav)}>Play</button>
+                {fav.isContainer && (
+                  <button onClick={() => onBrowse(fav)}>Browse</button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteModal;


### PR DESCRIPTION
## Summary
- extend Favorite interface and show modal for container items
- implement browseFavorite method on server
- expose browseFavorite via GET handler
- add FavoriteModal component and styles
- document browsing feature

## Testing
- `npm run lint` *(fails: TypeError: Key "languageOptions": Key "globals": Global "AudioWorkletGlobalScope " has leading or trailing whitespace.)*

------
https://chatgpt.com/codex/tasks/task_e_684c344f2e1c832da351d901ce01088d