### PR TITLE
Resolve favorite container detection

### DIFF
--- a/server/sonos/index.ts
+++ b/server/sonos/index.ts
@@ -561,8 +561,8 @@ export class SonosHandler {
 
       this.sendLog(`Parsed Favorites XML`);
 
-      const metaParser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
-      const metaResult = await metaParser.parseStringPromise(favoritesResult);
+      const metadataParser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
+      const metaResult = await metadataParser.parseStringPromise(favoritesResult);
       let items = metaResult['DIDL-Lite'] && metaResult['DIDL-Lite']['item'];
 
       if (!items) {
@@ -576,14 +576,15 @@ export class SonosHandler {
       const favoritesList = await Promise.all(
         items.map(async (item: any) => {
           const title = item['dc:title'] || 'Unknown Title';
-          const uri = item['res'] || null;
+          const resVal = item['res'];
+          const uri = typeof resVal === 'object' ? resVal._ : resVal || null;
           const albumArtURI = item['upnp:albumArtURI'] || null;
           const metaData = item['r:resMD'] || item['resMD'] || '';
 
           let upnpClass = item['upnp:class'] || '';
           if (!upnpClass && metaData) {
             try {
-              const meta = await metaParser.parseStringPromise(metaData);
+              const meta = await metadataParser.parseStringPromise(metaData);
               const metaItem = meta['DIDL-Lite']?.item || meta['DIDL-Lite']?.container;
               upnpClass = metaItem?.['upnp:class'] || '';
             } catch (err: any) {
@@ -591,7 +592,7 @@ export class SonosHandler {
             }
           }
 
-          const isContainer = upnpClass.includes('object.container');
+          const isContainer = upnpClass.includes('object.container') || (!uri && !!item?.$?.id);
           const id = item?.$?.id || '';
 
           let formattedAlbumArtURI = albumArtURI;
@@ -652,8 +653,8 @@ export class SonosHandler {
     const parsed = await parser.parseStringPromise(response.data);
     const resultStr = parsed['s:Envelope']['s:Body']['u:BrowseResponse']['Result'];
 
-    const metaParser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
-    const metaResult = await metaParser.parseStringPromise(resultStr);
+    const metadataParser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
+    const metaResult = await metadataParser.parseStringPromise(resultStr);
     const rootAttrs = metaResult['DIDL-Lite'].$ || {};
     let containers: any[] = metaResult['DIDL-Lite']['container'] || [];
     let items: any[] = metaResult['DIDL-Lite']['item'] || [];
@@ -668,10 +669,11 @@ export class SonosHandler {
     const children = await Promise.all(
       allItems.map(async (child: any) => {
         const title = child['dc:title'] || 'Unknown Title';
-        const uri = child['res'] || null;
+        const childRes = child['res'];
+        const uri = typeof childRes === 'object' ? childRes._ : childRes || null;
         const albumArtURI = child['upnp:albumArtURI'] || null;
         const upnpClass = child['upnp:class'] || '';
-        const isContainer = upnpClass.includes('object.container');
+        const isContainer = upnpClass.includes('object.container') || (!uri && !!child?.$?.id);
         const meta = builder.buildObject({ 'DIDL-Lite': { $: rootAttrs, [isContainer ? 'container' : 'item']: child } });
         const idAttr = child?.$?.id || '';
 
@@ -740,7 +742,7 @@ export class SonosHandler {
   }
   
   
-  async playFavoriteOnSpeakers(uri: string, speakerUUIDs: string[]) {
+  async playFavoriteOnSpeakers(uri: any, speakerUUIDs: string[]) {
     if (speakerUUIDs.length === 0) {
       throw new Error('No speakers selected to play the favorite.');
     }
@@ -760,7 +762,8 @@ export class SonosHandler {
     }
 
     this.deviceIP = coordinatorIP;
-    await this.playFavorite(uri);
+    const uriString = typeof uri === 'object' && uri ? uri._ : uri;
+    await this.playFavorite(uriString);
 
     if (this.selectedSpeakerUUIDs && !this.selectedSpeakerUUIDs.includes(coordinatorUUID)) {
       this.selectedSpeakerUUIDs.unshift(coordinatorUUID);


### PR DESCRIPTION
## Summary
- add `metadataParser` to parse Sonos favorites
- fix detection logic for container favorites
- ensure favorite URIs are strings before playback

## Testing
- `npm run lint` *(fails: Key "languageOptions" ...)*
- `npm run build-server`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_684c3f4269b0832da23bb330bfb0f7dc