### PR TITLE
Fix favorite browsing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -11,3 +11,8 @@ const start = async () => {
 };
 
 DeskThing.on(DESKTHING_EVENTS.START, start);
+
+// Start immediately when this script is executed directly. The START event may
+// not fire if the backend is launched standalone, so this ensures all listeners
+// are registered and ready for GET requests.
+start();

--- a/server/setupGetters.ts
+++ b/server/setupGetters.ts
@@ -23,51 +23,58 @@ export const setupGetters = () => {
 
       case 'browseFavorite':
         if (payload?.id) {
-          const children = await sonos.browseFavorite(payload.id);
-          DeskThing.send({ app: 'sonos-webapp', type: 'favoriteChildren', payload: children });
+          try {
+            const children = await sonos.browseFavorite(payload.id);
+            DeskThing.send({
+              app: 'sonos-webapp',
+              type: 'favoriteChildren',
+              payload: children,
+            });
+          } catch (err: any) {
+            console.error(`Error browsing favorite: ${err.message}`);
+          }
         }
         break;
-        
-        case 'volume':
-       if (payload?.speakerUUIDs) {
-      try {
-      const volume = await sonos.getCurrentVolume(payload.speakerUUIDs);
-      DeskThing.send({
-        app: 'sonos-webapp',
-        type: 'currentVolume',
-        payload: {
-          volume,
-          uuid: payload.speakerUUIDs[0],
-        },
-      });
-    } catch (err: any) {
-      console.error(`Error fetching volume: ${err.message}`);
-    }
-  } else {
-    console.error('No speaker UUIDs provided for volume request');
-  }
-  break;
 
-  case 'currentVolume': {
-    const uuids = data.payload?.speakerUUIDs || sonos.selectedVolumeSpeakers;
-    if (!uuids || uuids.length === 0) {
-      console.error('No speaker UUIDs provided for volume request');
-      return;
-    }
-  
-    try {
-      const volume = await sonos.getCurrentVolume(uuids);
-      DeskThing.send({
-        app: 'sonos-webapp',
-        type: 'currentVolume',
-        payload: { volume, uuid: uuids[0] },
-      });
-    } catch (error: any) {
-      console.error(`Error fetching volume: ${error.message}`);
-    }
-    break;
-  }
-  
+      case 'volume':
+        if (payload?.speakerUUIDs) {
+          try {
+            const volume = await sonos.getCurrentVolume(payload.speakerUUIDs);
+            DeskThing.send({
+              app: 'sonos-webapp',
+              type: 'currentVolume',
+              payload: {
+                volume,
+                uuid: payload.speakerUUIDs[0],
+              },
+            });
+          } catch (err: any) {
+            console.error(`Error fetching volume: ${err.message}`);
+          }
+        } else {
+          console.error('No speaker UUIDs provided for volume request');
+        }
+        break;
+
+      case 'currentVolume': {
+        const uuids = payload?.speakerUUIDs || sonos.selectedVolumeSpeakers;
+        if (!uuids || uuids.length === 0) {
+          console.error('No speaker UUIDs provided for volume request');
+          break;
+        }
+
+        try {
+          const volume = await sonos.getCurrentVolume(uuids);
+          DeskThing.send({
+            app: 'sonos-webapp',
+            type: 'currentVolume',
+            payload: { volume, uuid: uuids[0] },
+          });
+        } catch (error: any) {
+          console.error(`Error fetching volume: ${error.message}`);
+        }
+        break;
+      }
 
       case 'selectedVolumeSpeakers':
         DeskThing.send({


### PR DESCRIPTION
## Summary
- invoke `start()` directly in `server/index.ts` so the backend initializes without a START event
- add try/catch when browsing a favorite and when fetching volume
- revert `server/index.js` to the previous compiled output

## Testing
- `npm run lint` *(fails: @typescript-eslint rules not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c76dc7eb8832d8fac0a56afc12524