### PR TITLE
Improve favorite modal UI

### DIFF
--- a/src/components/FavoriteModal.css
+++ b/src/components/FavoriteModal.css
@@ -46,3 +46,9 @@
 .close-button {
   margin-bottom: 10px;
 }
+
+.empty-message {
+  text-align: center;
+  padding: 20px;
+  color: #fff;
+}

--- a/src/components/FavoriteModal.tsx
+++ b/src/components/FavoriteModal.tsx
@@ -16,20 +16,24 @@ const FavoriteModal: React.FC<Props> = ({ items, onClose, onPlay, onBrowse }) =>
         <button className="close-button" onClick={onClose}>
           Close
         </button>
-        <div className="modal-grid">
-          {items.map((fav) => (
-            <div key={fav.id} className="modal-item">
-              <img src={fav.albumArt || ''} alt={fav.title} />
-              <div className="modal-title">{fav.title}</div>
-              <div className="modal-actions">
-                <button onClick={() => onPlay(fav)}>Play</button>
-                {fav.isContainer && (
-                  <button onClick={() => onBrowse(fav)}>Browse</button>
-                )}
+        {items.length === 0 ? (
+          <div className="empty-message">No items found.</div>
+        ) : (
+          <div className="modal-grid">
+            {items.map((fav) => (
+              <div key={fav.id} className="modal-item">
+                <img src={fav.albumArt || ''} alt={fav.title} />
+                <div className="modal-title">{fav.title}</div>
+                <div className="modal-actions">
+                  <button onClick={() => onPlay(fav)}>Play</button>
+                  {fav.isContainer && (
+                    <button onClick={() => onBrowse(fav)}>Browse</button>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -89,6 +89,7 @@ const Favorites = () => {
 
     const handleFavoriteChildren = (socketData: SocketData) => {
       if (socketData.type === 'favoriteChildren') {
+        console.log('Received favoriteChildren:', socketData.payload);
         setModalItems(socketData.payload);
         setShowModal(true);
       }


### PR DESCRIPTION
## Summary
- show a helpful message when browsing a favorite container with no items
- log container payloads for debugging

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unnecessary-condition' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c99ac8db8832d9a00409ad8b9e9d6