### PR TITLE
Fix SOAP result check

### DIFF
--- a/server/sonos/index.ts
+++ b/server/sonos/index.ts
@@ -659,7 +659,27 @@ export class SonosHandler {
 
       const parser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
       const parsed = await parser.parseStringPromise(response.data);
-      const resultStr = parsed['s:Envelope']['s:Body']['u:BrowseResponse']['Result'];
+
+      const envelope = parsed?.['s:Envelope'];
+      if (!envelope) {
+        this.sendError('[browseFavorite] SOAP response missing s:Envelope');
+        return [];
+      }
+      const body = envelope?.['s:Body'];
+      if (!body) {
+        this.sendError('[browseFavorite] SOAP response missing s:Body');
+        return [];
+      }
+      const browseResp = body?.['u:BrowseResponse'];
+      if (!browseResp) {
+        this.sendError('[browseFavorite] SOAP response missing u:BrowseResponse');
+        return [];
+      }
+      const resultStr = browseResp?.['Result'];
+      if (!resultStr) {
+        this.sendError('[browseFavorite] SOAP response missing u:BrowseResponse.Result');
+        return [];
+      }
 
       const metadataParser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
       const metaResult = await metadataParser.parseStringPromise(resultStr);


### PR DESCRIPTION
## Summary
- validate parsed SOAP body in `browseFavorite`
- return empty array if required field is missing

## Testing
- `npm run lint` *(fails: Definition for rules not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb32639b0832d82999863ae5fa42c