### PR TITLE
Fix browseFavorite metadata parsing

### DIFF
--- a/server/sonos/index.ts
+++ b/server/sonos/index.ts
@@ -661,15 +661,12 @@ export class SonosHandler {
       const parsed = await parser.parseStringPromise(response.data);
       const resultStr = parsed['s:Envelope']['s:Body']['u:BrowseResponse']['Result'];
 
-      const metadataParser = new xml2js.Parser({ explicitArray: false, ignoreAttrs: false });
+      const metadataParser = new xml2js.Parser({ explicitArray: true, ignoreAttrs: false });
       const metaResult = await metadataParser.parseStringPromise(resultStr);
       this.sendLog(`[browseFavorite] Raw meta result: ${JSON.stringify(metaResult).slice(0, 200)}...`);
       const rootAttrs = metaResult['DIDL-Lite'].$ || {};
-      let containers: any[] = metaResult['DIDL-Lite']['container'] || [];
-      let items: any[] = metaResult['DIDL-Lite']['item'] || [];
-
-    if (!Array.isArray(containers)) containers = [containers];
-    if (!Array.isArray(items)) items = [items];
+      const containers: any[] = metaResult['DIDL-Lite']['container'] || [];
+      const items: any[] = metaResult['DIDL-Lite']['item'] || [];
 
     const allItems = [...containers, ...items].filter(Boolean);
 


### PR DESCRIPTION
## Summary
- parse DIDL-Lite metadata with `explicitArray: true`
- rely on `xml2js` to always return arrays

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unnecessary-condition' was not found, many others)*

------
https://chatgpt.com/codex/tasks/task_e_684cb32f342c832da05c59b681ecc508