### PR TITLE
Fix object ID escaping in browseFavorite

### DIFF
--- a/server/sonos/index.ts
+++ b/server/sonos/index.ts
@@ -633,7 +633,7 @@ export class SonosHandler {
       <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
         <s:Body>
           <u:Browse xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1">
-            <ObjectID>${id}</ObjectID>
+            <ObjectID>${this.escape(id)}</ObjectID>
             <BrowseFlag>BrowseDirectChildren</BrowseFlag>
             <Filter>*</Filter>
             <StartingIndex>0</StartingIndex>


### PR DESCRIPTION
## Summary
- escape `ObjectID` in `browseFavorite`

## Testing
- `npm run build-server`

------
https://chatgpt.com/codex/tasks/task_e_684cb6983b90832d9a94d2ee0146e110