### PR TITLE
Improve SOAP error reporting for browsing favorites

### DIFF
--- a/src/components/FavoriteModal.tsx
+++ b/src/components/FavoriteModal.tsx
@@ -33,7 +33,13 @@ const FavoriteModal: React.FC<FavoriteModalProps> = ({ favoriteId, speakerIP, on
       }
     };
 
+    const handleError = (msg: string) => {
+      console.log('[FavoriteModal] Received browseFavoriteError:', msg);
+      setError(msg || 'Failed to browse favorite.');
+    };
+
     DeskThing.on('browseFavoriteResults', handleResults);
+    DeskThing.on('browseFavoriteError', handleError);
 
     DeskThing.send({
       app: 'sonos-webapp',
@@ -47,6 +53,7 @@ const FavoriteModal: React.FC<FavoriteModalProps> = ({ favoriteId, speakerIP, on
 
     return () => {
       DeskThing.off('browseFavoriteResults', handleResults);
+      DeskThing.off('browseFavoriteError', handleError);
     };
   }, [favoriteId, speakerIP]);
 


### PR DESCRIPTION
## Summary
- provide more detail about SOAP errors when requests fail
- send a dedicated `browseFavoriteError` event to the UI
- surface the error in `FavoriteModal` so users can see the message

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e01337fbc832db8376123d5e43bd4